### PR TITLE
pt-180362772 - Allow specific package versions to be packaged

### DIFF
--- a/deploy_kbs_layers.sh
+++ b/deploy_kbs_layers.sh
@@ -12,7 +12,7 @@ aws lambda list-layer-versions --layer-name kbs-Klayers-python38-aws-psycopg2 --
 $ROOT_DIR/scripts/deploy_with_docker/package.sh -p numpy        -l "https://www.numpy.org/license.html" -r python3.8 -a us-west-2
 aws lambda list-layer-versions --layer-name kbs-Klayers-python38-numpy --query LayerVersions[].[LayerVersionArn] --output text
 
-$ROOT_DIR/scripts/deploy_with_docker/package.sh -p pandas       -l BSD                                  -r python3.8 -a us-west-2
+$ROOT_DIR/scripts/deploy_with_docker/package.sh -p pandas       -l BSD                                  -r python3.8 -a us-west-2 -v 1.3.5
 aws lambda list-layer-versions --layer-name kbs-Klayers-python38-pandas --query LayerVersions[].[LayerVersionArn] --output text
 
 # schooner

--- a/scripts/deploy_with_docker/package.sh
+++ b/scripts/deploy_with_docker/package.sh
@@ -31,9 +31,10 @@
 
 LOG_FILE="$(date '+%d-%m-%y')_log.txt"
 
-while getopts ":p:r:l:a:x:b:" arg; do
+while getopts ":p:v:r:l:a:x:b:" arg; do
   case $arg in
     p) PACKAGE=$OPTARG;;  # Name of the python package to install
+    v) PACKAGE_VERSION=$OPTARG;; # Version of the python package to install
     r) LAYER_RUNTIME=$OPTARG;;  # Runtime version e.g. python3.7
     l) LAYER_LICENSE=$OPTARG;;  # License of package in SPIX 
     a) AWS_REGION=$OPTARG;;
@@ -50,7 +51,15 @@ then
 	echo "All variables -p <package_name> -r <runtime> -l <license> must be provided"
 	exit 1
 else 
+	if [ -z "$PACKAGE_VERSION" ]
+	then
+		PACKAGE_SPEC="$PACKAGE"
+	else
+		PACKAGE_SPEC="$PACKAGE"=="$PACKAGE_VERSION"
+	fi
+
 	printf "Layer Package : $PACKAGE\n" 2>&1 | tee -a "$LOG_FILE"
+	printf "Layer Full Package Spec: $PACKAGE_SPEC\n" 2>&1 | tee -a "$LOG_FILE"
 	printf "Layer Runtime : $LAYER_RUNTIME\n" 2>&1 | tee -a "$LOG_FILE"
 	printf "Layer License : $LAYER_LICENSE\n" 2>&1 | tee -a "$LOG_FILE"
 
@@ -105,7 +114,7 @@ $LAYER_RUNTIME -m venv venv/
 source venv/bin/activate
 printf "Pip-Installing $PACKAGE into virtualenv\n"
 pip install --upgrade pip >> "$LOG_FILE"
-pip install -q $PACKAGE >> "$LOG_FILE"
+pip install -q $PACKAGE_SPEC >> "$LOG_FILE"
 pip freeze > requirements.txt
 deactivate
 rm -rf venv/ # don't need the virtualenv anymore


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180362772

Updates to allow specific versions of a package to be selected for the layer.   The recently released pandas versions 1.4+ have a soft dependency on sql alchemy that causes errors, so this explicitly allows us to package the latest 1.3.x version.

`arn:aws:lambda:us-west-2:529513974030:layer:kbs-Klayers-python38-pandas:3` has been pushed with pandas 1.3.5.